### PR TITLE
Bump up prom-client dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@types/supertest": "^6.0.2",
         "chalk": "^4.1.2",
         "chokidar": "^3.6.0",
-        "prom-client": "^14.2.0",
+        "prom-client": "^15.1.2",
         "response-time": "^2.3.2",
         "rollup": "^4.14.3",
         "undici": "^5.27.2",
@@ -2682,6 +2682,14 @@
       "dependencies": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.8.0.tgz",
+      "integrity": "sha512-I/s6F7yKUDdtMsoBWXJe8Qz40Tui5vsuKCWJEWVL+5q9sSWRzzx6v2KeNsOBEwd94j0eWkpWCH4yB6rZg9Mf0w==",
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
     "node_modules/@polka/url": {
@@ -7821,14 +7829,15 @@
       "dev": true
     },
     "node_modules/prom-client": {
-      "version": "14.2.0",
-      "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-14.2.0.tgz",
-      "integrity": "sha512-sF308EhTenb/pDRPakm+WgiN+VdM/T1RaHj1x+MvAuT8UiQP8JmOEbxVqtkbfR4LrvOg5n7ic01kRBDGXjYikA==",
+      "version": "15.1.2",
+      "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-15.1.2.tgz",
+      "integrity": "sha512-on3h1iXb04QFLLThrmVYg1SChBQ9N1c+nKAjebBjokBqipddH3uxmOUcEkTnzmJ8Jh/5TSUnUqS40i2QB2dJHQ==",
       "dependencies": {
+        "@opentelemetry/api": "^1.4.0",
         "tdigest": "^0.1.1"
       },
       "engines": {
-        "node": ">=10"
+        "node": "^16 || ^18 || >=20"
       }
     },
     "node_modules/proxy-addr": {
@@ -11428,6 +11437,11 @@
           }
         }
       }
+    },
+    "@opentelemetry/api": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.8.0.tgz",
+      "integrity": "sha512-I/s6F7yKUDdtMsoBWXJe8Qz40Tui5vsuKCWJEWVL+5q9sSWRzzx6v2KeNsOBEwd94j0eWkpWCH4yB6rZg9Mf0w=="
     },
     "@polka/url": {
       "version": "1.0.0-next.23",
@@ -15114,10 +15128,11 @@
       "dev": true
     },
     "prom-client": {
-      "version": "14.2.0",
-      "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-14.2.0.tgz",
-      "integrity": "sha512-sF308EhTenb/pDRPakm+WgiN+VdM/T1RaHj1x+MvAuT8UiQP8JmOEbxVqtkbfR4LrvOg5n7ic01kRBDGXjYikA==",
+      "version": "15.1.2",
+      "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-15.1.2.tgz",
+      "integrity": "sha512-on3h1iXb04QFLLThrmVYg1SChBQ9N1c+nKAjebBjokBqipddH3uxmOUcEkTnzmJ8Jh/5TSUnUqS40i2QB2dJHQ==",
       "requires": {
+        "@opentelemetry/api": "^1.4.0",
         "tdigest": "^0.1.1"
       }
     },

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "@types/supertest": "^6.0.2",
     "chalk": "^4.1.2",
     "chokidar": "^3.6.0",
-    "prom-client": "^14.2.0",
+    "prom-client": "^15.1.2",
     "response-time": "^2.3.2",
     "rollup": "^4.14.3",
     "undici": "^5.27.2",


### PR DESCRIPTION
- Release notes - https://github.com/siimon/prom-client/releases
- There are no breaking changes in prom-client other than dropping support for older nodejs versions.
- We can get benefitted from the performance improvements done.