### PR TITLE
Add support for custom metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.2]
+
+### Added
+
+- Exposed `prom-client` using `getMetricClient` function.
+
+## [0.9.1]
+
+### Updated
+
+- Improved Next.js parameterized route capturing capability
+
 ## [0.9.0]
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Exposed `prom-client` using `getMetricClient` function.
 
+### Updates
+
+- Upgrade `prom-client`
+
 ## [0.9.1]
 
 ### Updated

--- a/README.md
+++ b/README.md
@@ -249,6 +249,32 @@ const handler = () => {
 };
 ```
 
+5. Defining custom metrics
+
+OpenAPM exposes underlying `prom-client` via `metricClient` function.
+
+``` js
+const {
+  metricClient
+} = require('@last9/openapm');
+
+// initialize custom metric
+const client = metricClient();
+const counter = new client.Counter({
+  name: 'cancelation_calls',
+  help: 'no. of times cancel operation is called'
+});
+
+// handler
+app.get('/cancel/:ids', (req, res) => {
+  counter.inc();
+  res.status(200).json({});
+});
+```
+
+Follow the [documentation of prom-client](https://github.com/siimon/prom-client?tab=readme-ov-file#custom-metrics)
+to get familiar with the DSL for defining custom metrics.
+
 ## Setup locally
 
 Make sure you are in the express directory.

--- a/README.md
+++ b/README.md
@@ -251,15 +251,13 @@ const handler = () => {
 
 5. Defining custom metrics
 
-OpenAPM exposes underlying `prom-client` via `metricClient` function.
+OpenAPM exposes underlying `prom-client` via `getMetricClient` function.
 
-``` js
-const {
-  metricClient
-} = require('@last9/openapm');
+```js
+const { getMetricClient } = require('@last9/openapm');
 
 // initialize custom metric
-const client = metricClient();
+const client = getMetricClient();
 const counter = new client.Counter({
   name: 'cancelation_calls',
   help: 'no. of times cancel operation is called'

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@last9/openapm",
-  "version": "0.9.3-alpha.4",
+  "version": "0.9.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@last9/openapm",
-      "version": "0.9.3-alpha.4",
+      "version": "0.9.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@prisma/client": "^5.13.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@last9/openapm",
-  "version": "0.9.3-alpha",
+  "version": "0.9.3-alpha.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@last9/openapm",
-      "version": "0.9.3-alpha",
+      "version": "0.9.3-alpha.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@prisma/client": "^5.13.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@last9/openapm",
-  "version": "0.9.3-alpha.2",
+  "version": "0.9.3-alpha.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@last9/openapm",
-      "version": "0.9.3-alpha.2",
+      "version": "0.9.3-alpha.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@prisma/client": "^5.13.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@last9/openapm",
-  "version": "0.9.3-alpha.3",
+  "version": "0.9.3-alpha.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@last9/openapm",
-      "version": "0.9.3-alpha.3",
+      "version": "0.9.3-alpha.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@prisma/client": "^5.13.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@last9/openapm",
-  "version": "0.9.1",
+  "version": "0.9.3-alpha",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@last9/openapm",
-      "version": "0.9.1",
+      "version": "0.9.3-alpha",
       "license": "Apache-2.0",
       "dependencies": {
         "@prisma/client": "^5.13.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@last9/openapm",
   "description": "OpenAPM for Node.js",
-  "version": "0.9.3-alpha.3",
+  "version": "0.9.3-alpha.4",
   "main": "dist/src/index.js",
   "module": "dist/esm/src/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@last9/openapm",
   "description": "OpenAPM for Node.js",
-  "version": "0.9.1",
+  "version": "0.9.3-alpha",
   "main": "dist/src/index.js",
   "module": "dist/esm/src/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@last9/openapm",
   "description": "OpenAPM for Node.js",
-  "version": "0.9.3-alpha.4",
+  "version": "0.9.2",
   "main": "dist/src/index.js",
   "module": "dist/esm/src/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@last9/openapm",
   "description": "OpenAPM for Node.js",
-  "version": "0.9.3-alpha.2",
+  "version": "0.9.3-alpha.3",
   "main": "dist/src/index.js",
   "module": "dist/esm/src/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "version": "0.9.3-alpha.2",
   "main": "dist/src/index.js",
   "module": "dist/esm/src/index.js",
+  "types": "dist/index.d.ts",
   "scripts": {
     "build": "tsup",
     "build:watch": "tsup --watch",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@last9/openapm",
   "description": "OpenAPM for Node.js",
-  "version": "0.9.3-alpha",
+  "version": "0.9.3-alpha.2",
   "main": "dist/src/index.js",
   "module": "dist/esm/src/index.js",
   "scripts": {

--- a/playground/app.js
+++ b/playground/app.js
@@ -5,7 +5,11 @@
  *  */
 require('dotenv').config();
 const express = require('express');
-const { OpenAPM, setOpenAPMLabels } = require('../dist/src/index.js');
+const {
+  OpenAPM,
+  setOpenAPMLabels,
+  metricClient
+} = require('../dist/src/index.js');
 const mysql2 = require('mysql2');
 
 const openapm = new OpenAPM({
@@ -37,6 +41,12 @@ const pool = mysql2.createPool(
   'mysql://express-app:password@127.0.0.1/express' //  If this throws an error, Change the db url to the one you're running on your machine locally or the testing instance you might have hosted.
 );
 
+const client = metricClient();
+const counter = new client.Counter({
+  name: 'cancelation_calls',
+  help: 'no. of times cancel operation is called'
+});
+
 app.get('/result', (req, res) => {
   pool.getConnection((err, conn) => {
     conn.query(
@@ -59,6 +69,7 @@ app.get('/organizations/:org/users', (req, res) => {
 });
 
 app.get('/cancel/:ids', (req, res) => {
+  counter.inc();
   res.status(200).json({});
 });
 

--- a/src/OpenAPM.ts
+++ b/src/OpenAPM.ts
@@ -471,4 +471,8 @@ export class OpenAPM extends LevitateEvents {
   }
 }
 
+export function metricClient() {
+  return promClient;
+}
+
 export default OpenAPM;

--- a/src/OpenAPM.ts
+++ b/src/OpenAPM.ts
@@ -436,16 +436,16 @@ export class OpenAPM extends LevitateEvents {
         instrumentNestFactory(NestFactory, this._REDMiddleware);
       }
       if (moduleName === 'nextjs') {
-        const nextServer = require(
-          path.resolve('node_modules/next/dist/server/next-server.js')
-        );
+        const nextServer = require(path.resolve(
+          'node_modules/next/dist/server/next-server.js'
+        ));
 
         instrumentNextjs(
           nextServer.default,
           {
-            getRequestMeta: require(
-              path.resolve('node_modules/next/dist/server/request-meta.js')
-            ).getRequestMeta
+            getRequestMeta: require(path.resolve(
+              'node_modules/next/dist/server/request-meta.js'
+            )).getRequestMeta
           },
           {
             counter: this.requestsCounter,
@@ -471,7 +471,7 @@ export class OpenAPM extends LevitateEvents {
   }
 }
 
-export function metricClient() {
+export function getMetricClient() {
   return promClient;
 }
 

--- a/src/OpenAPM.ts
+++ b/src/OpenAPM.ts
@@ -436,16 +436,16 @@ export class OpenAPM extends LevitateEvents {
         instrumentNestFactory(NestFactory, this._REDMiddleware);
       }
       if (moduleName === 'nextjs') {
-        const nextServer = require(path.resolve(
-          'node_modules/next/dist/server/next-server.js'
-        ));
+        const nextServer = require(
+          path.resolve('node_modules/next/dist/server/next-server.js')
+        );
 
         instrumentNextjs(
           nextServer.default,
           {
-            getRequestMeta: require(path.resolve(
-              'node_modules/next/dist/server/request-meta.js'
-            )).getRequestMeta
+            getRequestMeta: require(
+              path.resolve('node_modules/next/dist/server/request-meta.js')
+            ).getRequestMeta
           },
           {
             counter: this.requestsCounter,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,3 @@
-export { default as OpenAPM } from './OpenAPM';
+export { default as OpenAPM, metricClient } from './OpenAPM';
 export { setOpenAPMLabels } from './async-local-storage.http';
 export type { OpenAPMOptions } from './OpenAPM';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,3 @@
-export { default as OpenAPM, metricClient } from './OpenAPM';
+export { default as OpenAPM, getMetricClient } from './OpenAPM';
 export { setOpenAPMLabels } from './async-local-storage.http';
 export type { OpenAPMOptions } from './OpenAPM';

--- a/tests/express.test.ts
+++ b/tests/express.test.ts
@@ -10,6 +10,7 @@ import { writeFileSync } from 'fs';
 
 describe('REDMiddleware', () => {
   const NUMBER_OF_REQUESTS = 300;
+  const MEANING_OF_LIFE = 42;
   let openapm: OpenAPM;
   let app: Express;
   let parsedData: Array<Record<string, any>> = [];
@@ -49,7 +50,7 @@ describe('REDMiddleware', () => {
     ).toBe(NUMBER_OF_REQUESTS);
   });
 
-  test('Captures Custom Counter Metrics - App', async () => {
+  test('Captures Custom Counter Metric - App', async () => {
     expect(
       parseInt(
         parsedData?.find((m) => m.name === 'custom_counter_total')?.metrics[0]
@@ -70,6 +71,29 @@ describe('REDMiddleware', () => {
     // }
 
     expect(labels.service).toBe('express');
+    expect(labels.environment).toBe('production');
+    expect(labels.program).toBe('@last9/openapm');
+  });
+
+  test('Captures Custom Gauge Metric - App', async () => {
+    expect(
+      parseInt(
+        parsedData?.find((m) => m.name === 'custom_gauge')?.metrics[0].value ??
+          '0'
+      )
+    ).toBe(MEANING_OF_LIFE);
+
+    const labels = parsedData?.find((m) => m.name === 'custom_gauge')
+      ?.metrics[0].labels;
+
+    // {
+    //     environment: 'production',
+    //     program: '@last9/openapm',
+    //     version: '0.9.3-alpha',
+    //     host: 'Adityas-MacBook-Pro-2.local',
+    //     ip: '192.168.1.110'
+    // }
+
     expect(labels.environment).toBe('production');
     expect(labels.program).toBe('@last9/openapm');
   });

--- a/tests/express.test.ts
+++ b/tests/express.test.ts
@@ -50,13 +50,28 @@ describe('REDMiddleware', () => {
   });
 
   test('Captures Custom Counter Metrics - App', async () => {
-    console.log(parsedData);
     expect(
       parseInt(
-        parsedData?.find((m) => m.name === 'custom_counter')?.metrics[0]
+        parsedData?.find((m) => m.name === 'custom_counter_total')?.metrics[0]
           .value ?? '0'
       )
     ).toBe(NUMBER_OF_REQUESTS);
+
+    const labels = parsedData?.find((m) => m.name === 'custom_counter_total')
+      ?.metrics[0].labels;
+
+    // {
+    //     service: 'express',
+    //     environment: 'production',
+    //     program: '@last9/openapm',
+    //     version: '0.9.3-alpha',
+    //     host: 'Adityas-MacBook-Pro-2.local',
+    //     ip: '192.168.1.110'
+    // }
+
+    expect(labels.service).toBe('express');
+    expect(labels.environment).toBe('production');
+    expect(labels.program).toBe('@last9/openapm');
   });
 
   test('Captures Counter Metrics - Router', async () => {

--- a/tests/express.test.ts
+++ b/tests/express.test.ts
@@ -1,19 +1,21 @@
 import express, { Express } from 'express';
-import parsePrometheusTextFormat from 'parse-prometheus-text-format';
-import request from 'supertest';
 import { test, expect, describe, beforeAll, afterAll } from 'vitest';
 
-import OpenAPM from '../src/OpenAPM';
+import OpenAPM, { getMetricClient } from '../src/OpenAPM';
 import { addRoutes, makeRequest, sendTestRequests } from './utils';
 import prom from 'prom-client';
-import { writeFileSync } from 'fs';
 
 describe('REDMiddleware', () => {
   const NUMBER_OF_REQUESTS = 300;
   const MEANING_OF_LIFE = 42;
   let openapm: OpenAPM;
   let app: Express;
-  let parsedData: Array<Record<string, any>> = [];
+
+  const getMetrics = async () => {
+    const client = getMetricClient();
+    const parsedData = await client.register.getMetricsAsJSON();
+    return parsedData;
+  };
 
   beforeAll(async () => {
     openapm = new OpenAPM({
@@ -27,9 +29,6 @@ describe('REDMiddleware', () => {
     app.listen(3002);
 
     const out = await sendTestRequests(app, NUMBER_OF_REQUESTS);
-    // @ts-ignore
-    const res = await request(openapm.metricsServer).get('/metrics');
-    parsedData = parsePrometheusTextFormat(res.text);
   });
 
   afterAll(async () => {
@@ -42,25 +41,23 @@ describe('REDMiddleware', () => {
   test;
 
   test('Captures Counter Metrics - App', async () => {
+    const parsedData = await getMetrics();
+
     expect(
-      parseInt(
-        parsedData?.find((m) => m.name === 'http_requests_total')?.metrics[0]
-          .value ?? '0'
-      )
+      parsedData.find((m) => m.name === 'http_requests_total')?.values[0].value
     ).toBe(NUMBER_OF_REQUESTS);
   });
 
   test('Captures Custom Counter Metric - App', async () => {
-    expect(
-      parseInt(
-        parsedData?.find((m) => m.name === 'custom_counter_total')?.metrics[0]
-          .value ?? '0'
-      )
-    ).toBe(NUMBER_OF_REQUESTS);
+    const parsedData = await getMetrics();
 
-    const labels = parsedData?.find((m) => m.name === 'custom_counter_total')
-      ?.metrics[0].labels;
+    const customCounterMetric = parsedData.find(
+      (m) => m.name === 'custom_counter_total'
+    )?.values[0];
 
+    expect(customCounterMetric?.value).toBe(NUMBER_OF_REQUESTS);
+
+    const labels = customCounterMetric?.labels;
     // {
     //     service: 'express',
     //     environment: 'production',
@@ -70,21 +67,20 @@ describe('REDMiddleware', () => {
     //     ip: '192.168.1.110'
     // }
 
-    expect(labels.service).toBe('express');
-    expect(labels.environment).toBe('production');
-    expect(labels.program).toBe('@last9/openapm');
+    expect(labels?.service).toBe('express');
+    expect(labels?.environment).toBe('production');
+    expect(labels?.program).toBe('@last9/openapm');
   });
 
   test('Captures Custom Gauge Metric - App', async () => {
-    expect(
-      parseInt(
-        parsedData?.find((m) => m.name === 'custom_gauge')?.metrics[0].value ??
-          '0'
-      )
-    ).toBe(MEANING_OF_LIFE);
+    const parsedData = await getMetrics();
 
-    const labels = parsedData?.find((m) => m.name === 'custom_gauge')
-      ?.metrics[0].labels;
+    const customGaugeMetric = parsedData.find((m) => m.name === 'custom_gauge')
+      ?.values[0];
+
+    expect(customGaugeMetric?.value).toBe(MEANING_OF_LIFE);
+
+    const labels = customGaugeMetric?.labels;
 
     // {
     //     environment: 'production',
@@ -94,53 +90,56 @@ describe('REDMiddleware', () => {
     //     ip: '192.168.1.110'
     // }
 
-    expect(labels.environment).toBe('production');
-    expect(labels.program).toBe('@last9/openapm');
+    expect(labels?.environment).toBe('production');
+    expect(labels?.program).toBe('@last9/openapm');
   });
 
   test('Captures Counter Metrics - Router', async () => {
+    const parsedData = await getMetrics();
+    const metric = parsedData.find((m) => m.name === 'http_requests_total');
+
     expect(
-      parseInt(
-        parsedData?.find((m) => m.name === 'http_requests_total')?.metrics[1]
-          .value ?? '0'
-      )
+      metric?.values.find((m) => m.labels.path === '/api/router/:id')?.value
     ).toBe(1);
   });
 
   test('Captures Histogram Metrics', async () => {
-    expect(
-      Object.keys(
-        parsedData?.find(
-          (m) => m.name === 'http_requests_duration_milliseconds'
-        )?.metrics[0].buckets
-      ).length > 0
-    ).toBe(true);
+    const parsedData = await getMetrics();
+
+    const metric = parsedData.find(
+      (m) => m.name === 'http_requests_duration_milliseconds'
+    );
+
+    expect(metric?.values?.length && metric.values.length > 0).toBe(true);
   });
 
   test('Masks the path - App', async () => {
-    expect(
-      parsedData?.find((m) => m.name === 'http_requests_total')?.metrics[0]
-        .labels.path
-    ).match(/api(?:\/router)?\/:id/);
+    const parsedData = await getMetrics();
+
+    const metric = parsedData.find((m) => m.name === 'http_requests_total');
+
+    expect(metric?.values[0].labels.path).match(/api(?:\/router)?\/:id/);
   });
 
   test('Masks the path - Router', async () => {
-    expect(
-      parsedData?.find((m) => m.name === 'http_requests_total')?.metrics[1]
-        .labels.path
-    ).match(/api(?:\/router)?\/:id/);
+    const client = getMetricClient();
+    const parsedData = await client.register.getMetricsAsJSON();
+    const metric = parsedData.find((m) => m.name === 'http_requests_total');
+
+    expect(metric?.values[1].labels.path).match(/api(?:\/router)?\/:id/);
   });
 
   test('Captures Dynamic Labels', async () => {
     await makeRequest(app, '/api/labels/123');
     // @ts-ignore
-    const res = await request(openapm.metricsServer).get('/metrics');
-    parsedData = parsePrometheusTextFormat(res.text);
+    const parsedData = await getMetrics();
+
+    const metricValues = parsedData?.find(
+      (m) => m.name === 'http_requests_total'
+    )?.values;
 
     expect(
-      parsedData
-        ?.find((m) => m.name === 'http_requests_total')
-        ?.metrics?.find((m) => m.labels.path === '/api/labels/:id').labels.id
+      metricValues?.find((m) => m.labels.path === '/api/labels/:id')?.labels.id
     ).toBe('123');
   });
 });

--- a/tests/express.test.ts
+++ b/tests/express.test.ts
@@ -49,6 +49,15 @@ describe('REDMiddleware', () => {
     ).toBe(NUMBER_OF_REQUESTS);
   });
 
+  test('Captures Custom Counter Metrics - App', async () => {
+    expect(
+      parseInt(
+        parsedData?.find((m) => m.name === 'custom_counter')?.metrics[0]
+          .value ?? '0'
+      )
+    ).toBe(NUMBER_OF_REQUESTS);
+  });
+
   test('Captures Counter Metrics - Router', async () => {
     expect(
       parseInt(

--- a/tests/express.test.ts
+++ b/tests/express.test.ts
@@ -50,6 +50,7 @@ describe('REDMiddleware', () => {
   });
 
   test('Captures Custom Counter Metrics - App', async () => {
+    console.log(parsedData);
     expect(
       parseInt(
         parsedData?.find((m) => m.name === 'custom_counter')?.metrics[0]

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -15,9 +15,11 @@ export const addRoutes = (app: Express) => {
   router.get('/:id', (req, res) => {
     const { id } = req.params;
     ``;
+    // counter.inc();
     res.status(200).send(id);
   });
   app.use('/api/router/', router);
+
   app.get('/api/:id', (req, res) => {
     const { id } = req.params;
     counter.inc();

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -20,14 +20,6 @@ export const addRoutes = (app: Express) => {
     labelNames: ['service']
   });
 
-  // dummy counter to make sure the https://github.com/yunyu/parse-prometheus-text-format
-  // library parses the above counter into array from the text format.
-  // TODO: We should get rid of https://github.com/yunyu/parse-prometheus-text-format
-  const dummy = new client.Counter({
-    name: 'dummy_counter_total',
-    help: 'dummy counter'
-  });
-
   router.get('/:id', (req, res) => {
     const { id } = req.params;
     ``;

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -2,12 +2,12 @@ import request from 'supertest';
 import express from 'express';
 import type { Express } from 'express';
 import { setOpenAPMLabels } from '../src/async-local-storage.http';
-import { metricClient } from '../src/OpenAPM';
+import { getMetricClient } from '../src/OpenAPM';
 
 export const addRoutes = (app: Express) => {
   const router = express.Router();
 
-  const client = metricClient();
+  const client = getMetricClient();
 
   const gauge = new client.Gauge({
     name: 'custom_gauge',

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -2,9 +2,15 @@ import request from 'supertest';
 import express from 'express';
 import type { Express } from 'express';
 import { setOpenAPMLabels } from '../src/async-local-storage.http';
+import { metricClient } from '../src/OpenAPM';
 
 export const addRoutes = (app: Express) => {
   const router = express.Router();
+  const client = metricClient();
+  const counter = new client.Counter({
+    name: 'custom_counter',
+    help: 'no. of times operation is called'
+  });
 
   router.get('/:id', (req, res) => {
     const { id } = req.params;
@@ -14,6 +20,7 @@ export const addRoutes = (app: Express) => {
   app.use('/api/router/', router);
   app.get('/api/:id', (req, res) => {
     const { id } = req.params;
+    counter.inc();
     res.status(200).send(id);
   });
 

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -6,23 +6,40 @@ import { metricClient } from '../src/OpenAPM';
 
 export const addRoutes = (app: Express) => {
   const router = express.Router();
+
   const client = metricClient();
+
+  const gauge = new client.Gauge({
+    name: 'custom_gauge',
+    help: 'custom gauge'
+  });
+
   const counter = new client.Counter({
-    name: 'custom_counter',
-    help: 'no. of times operation is called'
+    name: 'custom_counter_total',
+    help: 'custom counter',
+    labelNames: ['service']
+  });
+
+  // dummy counter to make sure the https://github.com/yunyu/parse-prometheus-text-format
+  // library parses the above counter into array from the text format.
+  // TODO: We should get rid of https://github.com/yunyu/parse-prometheus-text-format
+  const dummy = new client.Counter({
+    name: 'dummy_counter_total',
+    help: 'dummy counter'
   });
 
   router.get('/:id', (req, res) => {
     const { id } = req.params;
     ``;
-    // counter.inc();
+    gauge.set(42);
     res.status(200).send(id);
   });
+
   app.use('/api/router/', router);
 
   app.get('/api/:id', (req, res) => {
     const { id } = req.params;
-    counter.inc();
+    counter.inc({ service: 'express' });
     res.status(200).send(id);
   });
 


### PR DESCRIPTION
- Users can import `metricClient` function from openapm and use it any of the files in app code to define custom metrics.
- This function internally uses prom-client's client so the same DSL is supported.