### PR TITLE
Don't track `ip` label

### DIFF
--- a/src/OpenAPM.ts
+++ b/src/OpenAPM.ts
@@ -35,7 +35,6 @@ export type ExtractFromParams = {
 export type DefaultLabels =
   | 'environment'
   | 'program'
-  | 'ip'
   | 'version'
   | 'host';
 
@@ -187,8 +186,7 @@ export class OpenAPM extends LevitateEvents {
       environment: this.environment,
       program: packageJson?.name ?? '',
       version: packageJson?.version ?? '',
-      host: os.hostname(),
-      ip: getHostIpAddress(),
+      host: os.hostname(),      
       ...this.defaultLabels
     };
 


### PR DESCRIPTION
- Historically, this label has been source of the high cardinality data.
- This is generally handled at the scraper level where instance or pod labels are automatically added.
- With support for adding custom labels to every request, users can add `ip` whenever appropriate, it doesn't need to be done by default.